### PR TITLE
Melhoria no Dockerfile para usar código local

### DIFF
--- a/backend-java/Dockerfile
+++ b/backend-java/Dockerfile
@@ -1,11 +1,9 @@
 FROM maven:3.6.0-jdk-8 as build
 
-ARG FOR_BRANCH=master
 RUN mkdir /usr/app
-RUN git clone https://github.com/forpdi/plataforma-for.git /usr/app/repo
+COPY ./ /usr/app/repo/backend-java
 
 WORKDIR /usr/app/repo/backend-java
-RUN git checkout ${FOR_BRANCH}
 
 COPY ./conf/docker.dev.properties /usr/app/repo/backend-java/prd.properties
 RUN mvn clean package -P prd

--- a/frontend-web/Dockerfile
+++ b/frontend-web/Dockerfile
@@ -4,11 +4,9 @@ FROM node:10-stretch AS build
 RUN npm i -g yarn node-gyp --force
 RUN mkdir /usr/app
 
-ARG FOR_BRANCH=master
-RUN git clone https://github.com/forpdi/plataforma-for.git /usr/app/repo
+COPY ./ /usr/app/repo/frontend-web
 
 WORKDIR /usr/app/repo/frontend-web
-RUN git checkout ${FOR_BRANCH}
 RUN NODE_ENV=development yarn --frozen-lockfile
 RUN NODE_ENV=production yarn build:docker
 


### PR DESCRIPTION
Fazendo o git clone dentro do Dockerfile pode levar o desenvolvedor ao erro (experiência própria tentando contonar um [erro](https://github.com/forpdi/plataforma-for/issues/351) da build mais recente), pois se ele baixar uma versão mais antiga do repositório usando o git e executar o Dockerfile, na realidade o container será sutilmente criado sempre em cima do código mais atualizado.

Além disso, como todo o código já foi baixado no clone inicial, é possível apenas copiar as pastas de backend e frontend para dentro dos containers.